### PR TITLE
Fixed credentials type

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -71,9 +71,8 @@ export class Logger {
     }
 
     remoteUser() : string {
-        let credentials = auth(this._request);
-        credentials = credentials ? credentials.name : "-";
-        return credentials;
+        const credentials: any = auth(this._request);
+        return credentials ? credentials.name : "-";
     }
 
     request(header: string) : string {


### PR DESCRIPTION
Fixes the following type error:
```
➜  organ (6dbe835) ✔ deno bundle mod.ts
Bundling file:///home/alicegg/Personal/contrib/organ/mod.ts
error: TS2339 [ERROR]: Property 'name' does not exist on type 'object'.
        credentials = credentials ? credentials.name : "-";
                                                ~~~~
    at file:///home/alicegg/Personal/contrib/organ/mod.ts:75:49

TS2322 [ERROR]: Type 'object' is not assignable to type 'string'.
        return credentials;
        ~~~~~~~~~~~~~~~~~~~
    at file:///home/alicegg/Personal/contrib/organ/mod.ts:76:9

Found 2 errors.
```